### PR TITLE
Remove offline device from list

### DIFF
--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -87,48 +87,8 @@ export class HomePage {
    */
   scanForNewBLEDevices = () => {
     this.statusMsg = 'Searching for devices...';
-
-    // A list of the discovered devices
-    let newDevices: Array<Device> = [];
-
-    //TODO: BUG: The completion function is never called.
-
-    // The ble-service returns an observable and we subscribe to it here
-    // This means that for every new device discovered the first function
-    // should run, and when it has discovered all the devices it should run
-    // the last one.
-    //TODO: unsubscribe at some point
-    this.bleService.scanForDevices().subscribe(
-      // function to be called for each new device discovered
-      bleDevice => {
-        let device = this.devicesService.convertBleDeviceToDevice(bleDevice);
-        //debugging
-        this.statusMsg = 'Found device: ' + JSON.stringify(device);
-        //test that we don't add the same device twice
-        if (!newDevices.map(function(a) {return a.id}).includes(device.id) &&
-          this.devicesService.isNewDevice(device) &&
-          this.tilesApi.isTilesDevice(device)) {
-          this.mqttClient.registerDevice(device);
-          this.devicesService.newDevice(device);
-          newDevices.push(device);
-          //TODO: temporary, until we get the completion function to run
-          this.events.publish('updateDevices');
-        }
-      },
-      // function to be called if an error occurs
-      err => {
-        alert('Error when scanning for devices: ' + err);
-      },
-      // function to be called when the scan is complete
-      () => {
-        alert('No more devices');
-        // If we found any devices we should update the device list
-        if (newDevices.length > 0) {
-          this.events.publish('updateDevices');
-        }
-        console.log('\nNo more devices: ');
-      });
-    this.statusMsg = 'Done scanning';
+    this.devicesService.clearDisconnectedDevices();
+    this.bleService.scanForDevices();
   };
 
   /**

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -75,17 +75,10 @@ export class HomePage {
         }
       }
     });
-	  	
-	  this.events.subscribe('updateDevices', () => {
-	  	this.statusMsg = 'Updated list';
-	  	this.setDevices();
-	  	alert('updated devices: ' + this.devices)
-	  });
-
   };
 
   /**
-   *
+   * Set the devices equal to the devices from devicesservice
    */
   setDevices = () => {
     this.devices = this.devicesService.getDevices();
@@ -98,6 +91,7 @@ export class HomePage {
     this.statusMsg = 'Searching for devices...';
     this.devicesService.clearDisconnectedDevices();
     this.bleService.scanForDevices();
+    this.setDevices();
   };
 
   /**

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -31,7 +31,7 @@ export class HomePage {
               private alertCtrl: AlertController)
   {
 
-  	this.devices = devicesService.getDevices();
+  	this.setDevices();
   	this.serverConnectStatusMsg = 'Click to connect to server';
 
 
@@ -78,9 +78,18 @@ export class HomePage {
 	  	
 	  this.events.subscribe('updateDevices', () => {
 	  	this.statusMsg = 'Updated list';
+	  	this.setDevices();
+	  	alert('updated devices: ' + this.devices)
 	  });
 
   };
+
+  /**
+   *
+   */
+  setDevices = () => {
+    this.devices = this.devicesService.getDevices();
+  }
 
   /**
    * Use ble to discover new devices

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -34,26 +34,8 @@ export class HomePage {
   	this.devices = devicesService.getDevices();
   	this.serverConnectStatusMsg = 'Click to connect to server';
 
+
   	// Subscriptions to events that can be emitted from other places in the code
-  	//TODO: Dunno if these should be in the constructor or if that was a mistake
-	  this.events.subscribe('command', (deviceId: string, command: CommandObject) => {
-	    for (let device of this.devices) {
-	      if (device.id === deviceId) {
-	      	//alert('Recieved command from server: ' + JSON.stringify(command));
-	        device.ledOn = (command.name === 'led' && command.properties[0] === 'on');
-	        console.log('Device led on: ' + device.ledOn);
-	        const commandString = this.tilesApi.getCommandObjectAsString(command);
-	        this.bleService.sendData(device, commandString);
-
-        }
-      }
-    });
-
-	  this.events.subscribe('updateDevices', () => {
-	  	this.statusMsg = 'Updating list of devices';
-	  	this.devices = devicesService.getDevices();
-	  	this.statusMsg = this.devices.toString();
-	  });
 
     this.events.subscribe('serverConnected', () => {
       this.serverConnectStatusMsg = 'Connected to server';
@@ -79,6 +61,25 @@ export class HomePage {
       this.mqttClient.setServerConnectionStatus(false);
       this.serverConnectStatusMsg = 'Error: ${err}';
     });
+
+  	//TODO: Dunno if these should be in the constructor or if that was a mistake
+	  this.events.subscribe('command', (deviceId: string, command: CommandObject) => {
+	    for (let device of this.devices) {
+	      if (device.id === deviceId) {
+	      	//alert('Recieved command from server: ' + JSON.stringify(command));
+	        device.ledOn = (command.name === 'led' && command.properties[0] === 'on');
+	        console.log('Device led on: ' + device.ledOn);
+	        const commandString = this.tilesApi.getCommandObjectAsString(command);
+	        this.bleService.sendData(device, commandString);
+
+        }
+      }
+    });
+	  	
+	  this.events.subscribe('updateDevices', () => {
+	  	this.statusMsg = 'Updated list';
+	  });
+
   };
 
   /**
@@ -185,4 +186,4 @@ export class HomePage {
     });
     alert.present();
   };
-}
+};

--- a/GATEWAY/src/providers/ble.service.ts
+++ b/GATEWAY/src/providers/ble.service.ts
@@ -146,7 +146,7 @@ export class BleService {
 	 * @param {Device} device - the target device
 	 */
   connect = (device: Device) => {
-    //TODO: unsubscribe at some point
+    //TODO: unsubscribe at some point ? 
     //alert('connecting to device: ' + device.name)
   	BLE.connect(device.id)
   		  .subscribe(
@@ -163,10 +163,12 @@ export class BleService {
             }
         },
         err => {
-          console.log('Failed to connect to device ' + device.name)
+          device.connected = false;
+          this.disconnect(device);
+          alert('Lost connection to ' + device.name)
         },
         () => {
-          console.log('Connection attempt completed')
+          alert('Connection attempt completed')
         });
   };
 
@@ -222,7 +224,11 @@ export class BleService {
   					.then( res => {
   						device.connected = false;
   						this.mqttClient.unregisterDevice(device);
+              this.devicesService.clearDisconnectedDevices();
   					})
-  					.catch( err => console.log('Failed to disconnect'))
+  					.catch( err => {
+              console.log('Failed to disconnect')
+              device.connected = false;
+            });
   };
 }

--- a/GATEWAY/src/providers/ble.service.ts
+++ b/GATEWAY/src/providers/ble.service.ts
@@ -4,7 +4,7 @@ import { Events } from 'ionic-angular';
 import 'rxjs/add/operator/toPromise';
 import { MqttClient } from './mqttClient';
 import { TilesApi, CommandObject } from './tilesApi.service';
-import { Device }from './devices.service';
+import { Device, DevicesService }from './devices.service';
 
 // A dictionary of new device names set by user
 let tileNames = {};
@@ -27,7 +27,8 @@ export class BleService {
 
   constructor(public events: Events,
               private mqttClient: MqttClient,
-  						private tilesApi: TilesApi) {
+  						private tilesApi: TilesApi,
+              private devicesService: DevicesService) {
   };
 
   /**
@@ -58,29 +59,69 @@ export class BleService {
 
   /**
    * Checking if bluetooth is enabled and enable on android if not
+   * never used atm
    */
-  doRefresh = () => {
-  	BLE.isEnabled()
+  scanForDevices = () => {
+    BLE.isEnabled()
 		  		  .then( res => {
-		   		 		console.log('Bluetooth is enabled');
-		   		 		this.scanForDevices();
+		   		 		this.scanBLE();
 		   		 	})
 		  		  .catch( err => {
-		  		 		console.log('Bluetooth not enabled!');
-		  		 		// NB! Android only!! IOS users has to be told to turn bluetooth on
+		  		 		alert('Bluetooth not enabled!');
+		  		 		// NB! Android only!! IOS users has to turn bluetooth on manually
 		  		 		BLE.enable()
-				  		 			  .then( res => console.log('Bluetooth has been enabled'))
-				  		 			  .catch( err => console.log('Failed to enable bluetooth'));
+				  		 	 .then( res => {
+                    alert('Bluetooth has been enabled');
+                    this.scanBLE();
+                  })
+				    		 .catch( err => {
+                    alert('Failed to enable bluetooth, try doing it manually');
+                  });
 		  		  });
   };
 
   /**
    * Checking to see if any bluetooth devices are in reach
    */
-  scanForDevices = () => {
-		// The first param is the UUIDs to discover, this might
- 		// be specified to only search for tiles.
- 		return BLE.scan([], 30);
+  scanBLE = () => {
+    // A list of the discovered devices
+    let newDevices: Array<Device> = [];
+    //TODO: BUG: The completion function is never called.
+
+    // The ble-service returns an observable and we subscribe to it here
+    // This means that for every new device discovered the first function
+    // should run, and when it has discovered all the devices it should run
+    // the last one.
+    //TODO: unsubscribe at some point
+    BLE.scan([], 30).subscribe(
+      // function to be called for each new device discovered
+      bleDevice => {
+        let device = this.devicesService.convertBleDeviceToDevice(bleDevice);
+
+        //test that we don't add the same device twice and only add tiles devices
+        if (!newDevices.map(function(a) {return a.id}).includes(device.id) &&
+                                   this.devicesService.isNewDevice(device) &&
+                                   this.tilesApi.isTilesDevice(device)) {
+          this.mqttClient.registerDevice(device);
+          this.devicesService.newDevice(device);
+          newDevices.push(device);
+          //TODO: temporary, until we get the completion function to run
+          this.events.publish('updateDevices');
+        }
+      },
+      // function to be called if an error occurs
+      err => {
+        alert('Error when scanning for devices: ' + err);
+      },
+      // function to be called when the scan is complete
+      () => {
+        alert('No more devices');
+        // If we found any devices we should update the device list
+        if (newDevices.length > 0) {
+          this.events.publish('updateDevices');
+        }
+        console.log('\nNo more devices: ');
+      });
   };
 
   /**

--- a/GATEWAY/src/providers/devices.service.ts
+++ b/GATEWAY/src/providers/devices.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Events } from 'ionic-angular';
 
 /**
  * Class for the devices, this makes it possible to specify the
@@ -17,7 +16,7 @@ export class Device {
 export class DevicesService {
 	devices: Device[];
 
-  constructor(private events: Events) {
+  constructor() {
     this.devices = [];
   };
 
@@ -90,7 +89,6 @@ export class DevicesService {
         this.devices.slice(i, 1);
       }
     }
-    this.events.publish('updateDevices');
   };
 };
 

--- a/GATEWAY/src/providers/devices.service.ts
+++ b/GATEWAY/src/providers/devices.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Events } from 'ionic-angular';
 
 /**
  * Class for the devices, this makes it possible to specify the
@@ -16,7 +17,7 @@ export class Device {
 export class DevicesService {
 	devices: Device[];
 
-  constructor() {
+  constructor(private events: Events) {
     this.devices = [];
   };
 
@@ -78,6 +79,19 @@ export class DevicesService {
   isNewDevice = (device: Device) => {
     return !this.devices.map(function(a) {return a.id}).includes(device.id);
   };
-}
+
+  /**
+   * Go through the list of registered devices and keep only those connected
+   */
+  clearDisconnectedDevices = () => {
+    for(let i = 0; i < this.devices.length; i++) {
+      const device = this.devices[i];
+      if (device.connected == false) {
+        this.devices.slice(i, 1);
+      }
+    }
+    this.events.publish('updateDevices');
+  };
+};
 
 export default {DevicesService, Device};

--- a/GATEWAY/src/providers/devices.service.ts
+++ b/GATEWAY/src/providers/devices.service.ts
@@ -86,7 +86,7 @@ export class DevicesService {
     for(let i = 0; i < this.devices.length; i++) {
       const device = this.devices[i];
       if (device.connected == false) {
-        this.devices.slice(i, 1);
+        this.devices.splice(i, 1);
       }
     }
   };


### PR DESCRIPTION
This will remove a device that has gone offline from the list when 1. The device was connected and then went offline, or 2. the user performs a refresh. It will rearrange the list of disconnected devices but otherwise it should work pretty well. 