### PR TITLE
Add ionic config to gitignore

### DIFF
--- a/GATEWAY/.gitignore
+++ b/GATEWAY/.gitignore
@@ -3,3 +3,5 @@ platforms/
 plugins/
 www/lib/
 www/
+
+.io-onfig.json


### PR DESCRIPTION
to make sure the app-id stays connected to the developer and not the project on ionic upload