### PR TITLE
tileID instead fo mac address and UUID

### DIFF
--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -63,7 +63,7 @@ export class HomePage {
 
 	  this.events.subscribe('command', (deviceId: string, command: CommandObject) => {
 	    for (let device of this.devices) {
-	      if (device.id === deviceId) {
+	      if (device.tileId === deviceId) {
 	      	//alert('Recieved command from server: ' + JSON.stringify(command));
 	        device.ledOn = (command.name === 'led' && command.properties[0] === 'on');
 	        console.log('Device led on: ' + device.ledOn);
@@ -104,7 +104,7 @@ export class HomePage {
   };
 
 	fetchEventMappings = (device: Device): void => {
-		this.tilesApi.fetchEventMappings(device.id);
+		this.tilesApi.fetchEventMappings(device.tileId);
 	};
 
   /**

--- a/GATEWAY/src/providers/ble.service.ts
+++ b/GATEWAY/src/providers/ble.service.ts
@@ -111,7 +111,7 @@ export class BleService {
   	  		 	device.ledOn = false;
   	  		 	device.connected = true;
             device.buttonPressed = false;
-  	        this.tilesApi.loadEventMappings(device.id);
+  	        this.tilesApi.loadEventMappings(device.tileId);
             this.mqttClient.registerDevice(device);
             this.startDeviceNotification(device);
             if (device.name in tileNames){
@@ -160,7 +160,7 @@ export class BleService {
                 alert('No response for ' + message.properties[0])
                 break;
             }
-            this.mqttClient.sendEvent(device.id, message);
+            this.mqttClient.sendEvent(device.tileId, message);
           }
         },
         err => {

--- a/GATEWAY/src/providers/devices.service.ts
+++ b/GATEWAY/src/providers/devices.service.ts
@@ -9,6 +9,7 @@ import { Events } from 'ionic-angular';
  */
 export class Device {
   id: string;
+  tileId: string; // IOS and android gets different id from the ble, so we use the tilename as a seond id
   name: string;
   connected: boolean;
   ledOn: boolean;
@@ -28,9 +29,9 @@ export class DevicesService {
    * Returns mock devices for testing purposes
    */
   getMockDevices = (): Device[] => ([
-  	{id: '01:23:45:67:89:AB', name: 'TI SensorTag1', connected: false, ledOn: false, buttonPressed: true},
-  	{id: '01:23:45:67:89:AC', name: 'TI SensorTag2', connected: true, ledOn: true, buttonPressed: true},
-  	{id: '01:23:45:67:89:AD', name: 'TI SensorTag3', connected: false, ledOn: false, buttonPressed: true},
+  	{id: '01:23:45:67:89:AB', tileId: 'Tile1', name: 'TI SensorTag1', connected: false, ledOn: false, buttonPressed: true},
+  	{id: '01:23:45:67:89:AC', tileId: 'Tile2', name: 'TI SensorTag2', connected: true, ledOn: true, buttonPressed: true},
+  	{id: '01:23:45:67:89:AD', tileId: 'Tile3', name: 'TI SensorTag3', connected: false, ledOn: false, buttonPressed: true},
   ]);
 
   /**
@@ -46,9 +47,10 @@ export class DevicesService {
    * @param {any} bleDevice - the returned device from the ble scan
    */
   convertBleDeviceToDevice = (bleDevice: any): Promise<Device>  => {
-    return this.storage.get(bleDevice.id).then( name => {
+    return this.storage.get(bleDevice.name).then( name => {
       return {
         id: bleDevice.id,
+        tileId: bleDevice.name,
         name: name !== null ? name : bleDevice.name,
         connected: false, 
         ledOn: false,
@@ -57,6 +59,7 @@ export class DevicesService {
     }).catch(err => {
       return {
         id: bleDevice.id,
+        tileId: bleDevice.name,
         name: bleDevice.name,
         connected: false, 
         ledOn: false,
@@ -81,7 +84,7 @@ export class DevicesService {
    * @param {any} device - The device to check
    */
   isNewDevice = (device: any): boolean => {
-    return !this.devices.map(storedDevice => storedDevice.id).includes(device.id);
+    return !this.devices.map(storedDevice => storedDevice.tileId).includes(device.tileId);
   };
 
   /**
@@ -90,9 +93,9 @@ export class DevicesService {
    * @param {string} name - the new name for the device
    */
   setCustomDeviceName = (device: Device, name: string): void => {
-    this.storage.set(device.id, name);
+    this.storage.set(device.tileId, name);
     for(let d of this.devices) {
-      if(d.id == device.id) {
+      if(d.tileId == device.tileId) {
         d.name = name;
       }
     }

--- a/GATEWAY/src/providers/mqttClient.ts
+++ b/GATEWAY/src/providers/mqttClient.ts
@@ -117,19 +117,19 @@ export class MqttClient {
 	registerDevice = (device: Device): void => {
 		if (this.client) {
 			this.client.publish(
-				this.getDeviceSpecificTopic(device.id, true) + '/active',
+				this.getDeviceSpecificTopic(device.tileId, true) + '/active',
 				'true',
 				this.publishOpts
 			);
       this.client.publish(
-      	this.getDeviceSpecificTopic(device.id, true) + '/name',
+      	this.getDeviceSpecificTopic(device.tileId, true) + '/name',
       	device.name,
       	this.publishOpts
       );
       this.client.subscribe(
-      	this.getDeviceSpecificTopic(device.id, false)
+      	this.getDeviceSpecificTopic(device.tileId, false)
       );
-      console.log('Registered device: ' + device.name + ' (' + device.id + ')');
+      console.log('Registered device: ' + device.name + ' (' + device.tileId + ')');
     }
   };
 
@@ -140,12 +140,12 @@ export class MqttClient {
   unregisterDevice = (device: Device): void => {
     if (this.client) {
       this.client.publish(
-      	this.getDeviceSpecificTopic(device.id, true) + '/active',
+      	this.getDeviceSpecificTopic(device.tileId, true) + '/active',
       	'false',
       	this.publishOpts
       );
       this.client.unsubscribe(
-      	this.getDeviceSpecificTopic(device.id, false)
+      	this.getDeviceSpecificTopic(device.tileId, false)
       );
     }
   };

--- a/GATEWAY/src/providers/tilesApi.service.ts
+++ b/GATEWAY/src/providers/tilesApi.service.ts
@@ -116,47 +116,47 @@ export class TilesApi {
 
   /**
    * Set the eventmapprings for a tile
-   * @param {string} tileID - The target tile
+   * @param {string} deviceId - The target tile
    * @param {any} - eventmappings to store for the tile
    */
-  setEventMappings = (tileId: string, eventMappings: any): void => {
+  setEventMappings = (deviceId: string, eventMappings: any): void => {
     // TODO: Set an interface for the eventMappings 
-    this.storage.set(this.username + '_' + tileId, eventMappings);
+    this.storage.set(this.username + '_' + deviceId, eventMappings);
   };
 
   /** 
    * Gets the mappings for a specific event for a tile
-   * @param {string} tileId - a tile 
+   * @param {string} deviceId - a tile 
    * @param {string} eventAsString - a string representation of the event
    */
-  getEventMapping = (tileId: string, eventAsString: string): any => {
+  getEventMapping = (deviceId: string, eventAsString: string): any => {
     if (this.eventMappings[this.username] == null ||
-        this.eventMappings[this.username][tileId] == null) {
-      this.loadEventMappings(tileId);
+        this.eventMappings[this.username][deviceId] == null) {
+      this.loadEventMappings(deviceId);
     }
-    return this.eventMappings[this.username][tileId][eventAsString];
+    return this.eventMappings[this.username][deviceId][eventAsString];
   };
 
   /**
    * Get the eventmappings that are stored in the apps storage
-   * @param {string} tileId - the tile to get events for
+   * @param {string} deviceId - the tile to get events for
    */
-  loadEventMappings = (tileId: string): void => {
-    const storedEventMappings = this.storage.get(`eventMappings_${this.username}_${tileId}`)
+  loadEventMappings = (deviceId: string): void => {
+    const storedEventMappings = this.storage.get(`eventMappings_${this.username}_${deviceId}`)
                                             .then( res => res);
     if (this.eventMappings[this.username] == null) {
       this.eventMappings[this.username] = {};
     }
-    this.eventMappings[this.username][tileId] =
+    this.eventMappings[this.username][deviceId] =
             this.extend(this.defaultEventMappings, storedEventMappings);
   };
 
   /**
    * Fetch the event mappings for the given tile from the web-server
-   * @param {string} tileId - The ID of the tile
+   * @param {string} deviceId - The ID of the tile
    */
-  fetchEventMappings = (tileId: string): void => {
-    const url = `http://${this.hostAddress}:${this.apiPort}/eventmappings/${this.username}/${tileId}`;
+  fetchEventMappings = (deviceId: string): void => {
+    const url = `http://${this.hostAddress}:${this.apiPort}/eventmappings/${this.username}/${deviceId}`;
     //alert(url)
     this.http.get(url)
             .toPromise()
@@ -167,9 +167,9 @@ export class TilesApi {
               this.eventMappings[this.username] =
                     this.eventMappings[this.username] == null ?
                     {} : this.eventMappings[this.username];
-              this.eventMappings[this.username][tileId] =
+              this.eventMappings[this.username][deviceId] =
                     this.extend(this.defaultEventMappings, fetchedEventMappings);
-              this.setEventMappings(tileId, this.eventMappings[this.username][tileId]);
+              this.setEventMappings(deviceId, this.eventMappings[this.username][deviceId]);
             })
             .catch(err => alert('failed fetching data with error: ' + err));
   };


### PR DESCRIPTION
use the ble name for tile id instead of using the mac address/UUID for communication with the server and for id within the app. device.idshould only be used for bluetooth purposes from now on. 