### PR TITLE
Pair tiles

### DIFF
--- a/GATEWAY/README.md
+++ b/GATEWAY/README.md
@@ -24,3 +24,4 @@ There are a lot of possible platforms to choose from, but for this projects we u
 With the platform added run 
 `$ ionic run <platform>`
 
+When using `ionic serve` or `ionic run <platform> -l` you might run into troubles with the api not working. This is because of CORS and can be solved by using onli `ionic run <platform>` withour the live reloading for running it on a simulator/mobile or by downloading the chrome extension [Allow-Control-Allow-Origin: *](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi)

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -23,6 +23,7 @@
     </ion-refresher-content>
   </ion-refresher>
   <ion-item no-lines>{{statusMsg}}</ion-item>
+  <ion-title left style="padding-left: 0;">PHYSICAL TILES</ion-title>
   <ion-list class="mainList">
     <ion-item class="devices" color="light" *ngFor="let device of devices">
       <div class="row row-center">
@@ -52,6 +53,7 @@
         </div>
       </ion-list>
     </ion-item>
+    <ion-title left style="padding-left: 0;">VIRTUAL TILES</ion-title>
     <ion-item class="devices" color="light" *ngFor="let tile of virtualTiles">
       <div class="row row-center">
         <div id="devName" class="col col-75">

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -57,10 +57,11 @@
     <ion-item class="devices" color="light" *ngFor="let tile of virtualTiles">
       <div class="row row-center">
         <div id="devName" class="col col-75">
-          <b>{{tile.virtualName}}</b><br><!--ID: {{device.tileId}}-->
-        </div>
+          <b>{{tile.virtualName}}</b><br>
         <div class="col">
-          <button class="bttn" ion-button small color="positive" (click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
+        <!--TODO: Change first parameter to a physical tile we want to pair to the virtual one-->
+          <button class="bttn" ion-button small color="positive" (
+          click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
         </div>
       </div>
     </ion-item>

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -60,7 +60,6 @@
           <b>{{tile.virtualName}}</b><br>
         </div>
         <div class="col">
-          <!--TODO: Change first parameter to a physical tile we want to pair to the virtual one-->
           <button class="bttn" ion-button small color="positive" (click)="pairTilePopUp(tile)" >PAIR</button>
         </div>
       </div>

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -61,7 +61,7 @@
         </div>
         <div class="col">
           <!--TODO: Change first parameter to a physical tile we want to pair to the virtual one-->
-          <button class="bttn" ion-button small color="positive" (click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
+          <button class="bttn" ion-button small color="positive" (click)="pairTilePopUp(tile)" >PAIR</button>
         </div>
       </div>
     </ion-item>

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -58,10 +58,10 @@
       <div class="row row-center">
         <div id="devName" class="col col-75">
           <b>{{tile.virtualName}}</b><br>
+        </div>
         <div class="col">
-        <!--TODO: Change first parameter to a physical tile we want to pair to the virtual one-->
-          <button class="bttn" ion-button small color="positive" (
-          click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
+          <!--TODO: Change first parameter to a physical tile we want to pair to the virtual one-->
+          <button class="bttn" ion-button small color="positive" (click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
         </div>
       </div>
     </ion-item>

--- a/GATEWAY/src/pages/home/home.html
+++ b/GATEWAY/src/pages/home/home.html
@@ -52,6 +52,16 @@
         </div>
       </ion-list>
     </ion-item>
+    <ion-item class="devices" color="light" *ngFor="let tile of virtualTiles">
+      <div class="row row-center">
+        <div id="devName" class="col col-75">
+          <b>{{tile.virtualName}}</b><br><!--ID: {{device.tileId}}-->
+        </div>
+        <div class="col">
+          <button class="bttn" ion-button small color="positive" (click)="tilesApi.pairDeviceToVirualTile('Tile_da', tile._id, 'test3')" >PAIR</button>
+        </div>
+      </div>
+    </ion-item>
   </ion-list>
 </ion-content>
 

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -34,6 +34,7 @@ export class HomePage {
               private tilesApi: TilesApi,
               private mqttClient: MqttClient) {
   	this.setDevices();
+    this.setVirtualTiles();
   	this.serverConnectStatusMsg = 'Click to connect to server';
 
   	// Subscriptions to events that can be emitted from other places in the code
@@ -92,6 +93,13 @@ export class HomePage {
    */
   setDevices = (): void => {
     this.devices = this.devicesService.getDevices();
+  }
+
+  setVirtualTiles = (): void => {
+    this.tilesApi.getApplicationTiles('test3').then(res => {
+      this.virtualTiles = res; 
+      console.log('tiles: ' + JSON.stringify(this.virtualTiles));
+    });
   }
 
   /**

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -5,7 +5,7 @@ import { Observable, Subscription } from 'rxjs';
 import { BleService } from '../../providers/ble.service';
 import { Device, DevicesService } from '../../providers/devices.service';
 import { MqttClient } from '../../providers/mqttClient';
-import { TilesApi, CommandObject } from '../../providers/tilesApi.service';
+import { TilesApi, CommandObject, VirtualTile } from '../../providers/tilesApi.service';
 
 @Component({
   selector: 'page-home',
@@ -23,6 +23,7 @@ export class HomePage {
   serverConnectStatusMsg: string;
   statusMsg: string;
   bleScanner: Subscription;
+  virtualTiles: VirtualTile[];
 
   constructor(public alertCtrl: AlertController,
               public navCtrl: NavController,

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -165,4 +165,29 @@ export class HomePage {
       }]
     }).present();
   };
+
+  /**
+   * Called when the pair button is pushed on the view of the the
+   * the virtual tiles.
+   * @param {VirtualTile} virtualTile - the target device
+   */
+  pairTilePopUp = (virtualTile: VirtualTile): void => {
+    const deviceRadioButtons = this.devices.map(device => {
+      return {type: 'radio', name: 'deviceId', value: device.tileId, label: device.name}
+    });
+    this.alertCtrl.create({
+      title: 'Pair to physical tile',
+      inputs: deviceRadioButtons,
+      buttons: [{
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Pair',
+          handler: data => {
+            this.tilesApi.pairDeviceToVirualTile(data, virtualTile._id, 'test3');
+          }
+      }]
+    }).present();
+  };
 };

--- a/GATEWAY/src/pages/home/home.ts
+++ b/GATEWAY/src/pages/home/home.ts
@@ -95,7 +95,11 @@ export class HomePage {
     this.devices = this.devicesService.getDevices();
   }
 
+  /**
+   * Set the virtual tiles equal to the ones stores for the app
+   */
   setVirtualTiles = (): void => {
+    //TODO: Use the appname for the chosen app when implemented
     this.tilesApi.getApplicationTiles('test3').then(res => {
       this.virtualTiles = res; 
       console.log('tiles: ' + JSON.stringify(this.virtualTiles));

--- a/GATEWAY/src/providers/tilesApi.service.ts
+++ b/GATEWAY/src/providers/tilesApi.service.ts
@@ -11,6 +11,15 @@ export class CommandObject {
   properties: string;
 }
 
+export class VirtualTile {
+  _id: string;
+  virtualName: string;
+  application: string;
+  tile: any;
+  __v: number;
+}
+
+
 
 @Injectable()
 export class TilesApi {

--- a/GATEWAY/src/providers/tilesApi.service.ts
+++ b/GATEWAY/src/providers/tilesApi.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Http }    from '@angular/http';
+import { Headers, Http }    from '@angular/http';
 import { Storage } from '@ionic/storage';
 import 'rxjs/add/operator/toPromise';
 
@@ -167,14 +167,17 @@ export class TilesApi {
    */
   pairDeviceToVirualTile = (deviceId: string, virtualTileId: string, applicationId: string): void => {
     const url = `http://${this.hostAddress}:${this.apiPort}/applications/${applicationId}/${virtualTileId}`;
-    const body = { tile: deviceId };
+    const body = JSON.stringify({ tile: deviceId });
+    const headerFields = new Headers({'Content-Type': 'application/json'});
+
+    console.log('url: ' + url + ' body: ' + body)
     // TODO: Device name must be updated to match the name of the virtual tile
-    this.http.post(url, body).toPromise()
+    this.http.post(url, body, {headers: headerFields}).toPromise()
              .then(res => {
-               // Do we even get a response? 
+               // Do we even get or need a response? 
              })
              .catch(err => {
-               alert('An error occured preventing the pairing of the physical and virtual tile');
+               console.log('An error occured preventing the pairing of the physical and virtual tile');
              });
   };
 

--- a/GATEWAY/src/providers/tilesApi.service.ts
+++ b/GATEWAY/src/providers/tilesApi.service.ts
@@ -35,7 +35,7 @@ export class TilesApi {
   };
   eventMappings = {};// {username: {tile: mappingsForTile}}
   username: string = 'TestUser';
-  hostAddress: string = '138.68.144.206';
+  hostAddress: string = '178.62.99.218';//'138.68.144.206';
   mqttPort: number = 8080;
   apiPort: number = 3000;
 
@@ -129,21 +129,34 @@ export class TilesApi {
             .then(res => {
               // TODO: do something with the applications here
             })
-            .catch(err => alert('failed getting applications with error: ' + err));
+            //.catch(err => alert('failed getting applications with error: ' + err));
   };
 
   /** 
    * Get the details of an application
    * @param {string} applicationId - The application ID
    */
-  getApplicationDetails = (applicationId: string): void => {
+  getApplicationDetails = (applicationId: string): Promise<any> => {
+    //const url = `http://${this.hostAddress}:${this.apiPort}/applications/${applicationId}`;
     const url = `http://${this.hostAddress}:${this.apiPort}/applications/${applicationId}`;
-    this.http.get(url)
+    return this.http.get(url)
             .toPromise()
             .then(res => {
-              // TODO: do something with the application here
+              return res.json();
             })
-            .catch(err => alert('failed getting applications with error: ' + err));
+            .catch(err => {
+              console.log('failed getting applications with error: ' + err);
+              console.log('url '+url)
+              return null;
+            });
+  };
+
+  /** 
+   * Get the tiles belonging to an application
+   * @param {string} applicationId - The application ID
+   */
+  getApplicationTiles = (applicationId: string): Promise<any> => {
+    return this.getApplicationDetails(applicationId).then(res => res.virtualTiles);
   };
 
   /**

--- a/GATEWAY/src/providers/tilesApi.service.ts
+++ b/GATEWAY/src/providers/tilesApi.service.ts
@@ -169,13 +169,8 @@ export class TilesApi {
     const url = `http://${this.hostAddress}:${this.apiPort}/applications/${applicationId}/${virtualTileId}`;
     const body = JSON.stringify({ tile: deviceId });
     const headerFields = new Headers({'Content-Type': 'application/json'});
-
     console.log('url: ' + url + ' body: ' + body)
-    // TODO: Device name must be updated to match the name of the virtual tile
     this.http.post(url, body, {headers: headerFields}).toPromise()
-             .then(res => {
-               // Do we even get or need a response? 
-             })
              .catch(err => {
                console.log('An error occured preventing the pairing of the physical and virtual tile');
              });


### PR DESCRIPTION
Adding a temporary list of virtual tiles below the physical ones and give them a pair button that will list the physical devices and pair the virtual one to the selected physical tile. All GUI is of course temporary and for debugging purposes (although with a few improvements I think this approach might be a good option). 
I do believe this should work, but the API doesn't seem to pich up the post request. The request should be in the correct format, so my best guess it that is has to do with a server bug. 