### PR TITLE
some bugfixes after the big gui-splitup merge

### DIFF
--- a/GATEWAY/src/pages/applications/applications.ts
+++ b/GATEWAY/src/pages/applications/applications.ts
@@ -93,7 +93,7 @@ export class ApplicationsPage {
     //push another page onto the history stack
     //causing the nav controller to animate the new page in
     this.navCtrl.push(VirtualTilesPage, {
-    	_id: application._id
+    	app: application,
     });
   }
 }

--- a/GATEWAY/src/pages/login/login.html
+++ b/GATEWAY/src/pages/login/login.html
@@ -14,7 +14,7 @@
     </ion-item>
     <ion-item>
       <ion-label>Host</ion-label>
-      <ion-input type="text" [(ngModel)]="loginInfo.host" name="host" placeholder='172.68.99.218'></ion-input>
+      <ion-input type="text" [(ngModel)]="loginInfo.host" name="host" placeholder='178.62.99.218'></ion-input>
     </ion-item>
     <ion-item>
       <ion-label>Port</ion-label>

--- a/GATEWAY/src/pages/virtual-tiles/virtual-tiles.ts
+++ b/GATEWAY/src/pages/virtual-tiles/virtual-tiles.ts
@@ -19,7 +19,6 @@ export class VirtualTilesPage {
 	applicationTitle: string;
   virtualTiles: VirtualTile[];
   activeApp: Application;
-  application_id = null;
 
   constructor(public alertCtrl: AlertController,
               public navCtrl: NavController, 
@@ -28,10 +27,10 @@ export class VirtualTilesPage {
               private utils: UtilsService,
               private tilesApi: TilesApi,) {
   	// A id variable is stored in the navParams, and .get set this value to the local variable id
-  	this.application_id = navParams.get('_id');
+  	this.activeApp = navParams.get('app');
 
   	// Sets the title of the page (found in virtual-tiles.html) to id, capitalized. 
-  	this.applicationTitle = utils.capitalize(this.application_id);
+  	this.applicationTitle = utils.capitalize(this.activeApp._id);
     this.setDevices();
     this.setVirtualTiles();
   }
@@ -72,7 +71,7 @@ export class VirtualTilesPage {
         {
           text: 'Pair',
           handler: data => {
-            this.tilesApi.pairDeviceToVirualTile(data, virtualTile._id, this.application_id);
+            this.tilesApi.pairDeviceToVirualTile(data, virtualTile._id, this.activeApp._id);
           },
       }],
     }).present();

--- a/GATEWAY/src/providers/ble.service.ts
+++ b/GATEWAY/src/providers/ble.service.ts
@@ -37,6 +37,7 @@ export class BleService {
    * Start the BLE scanner making it scan every 30s
    */
   startBLEScanner = (): void => {
+    this.scanForDevices([]);
     this.bleScanner = Observable.interval(30000).subscribe(res => {
       this.scanForDevices([]);
     });


### PR DESCRIPTION
Will make the physical devices appear straight away, also in the pairing list. Also passes the entre application to the virtual tiles page and set the placeholder server ip to the tiles api ip.